### PR TITLE
Add basic ImageJ / FIJI integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,12 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.scijava</groupId>
+        <artifactId>pom-scijava</artifactId>
+        <version>22.3.0</version>
+    </parent>
+
     <name>Java wrapper for LibAPR</name>
     <groupId>mosaic</groupId>
     <artifactId>libapr-java-wrapper</artifactId>
@@ -32,6 +38,16 @@
             <groupId>sc.fiji</groupId>
             <artifactId>bigdataviewer-vistools</artifactId>
             <version>1.0.0-beta-11</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.imagej</groupId>
+            <artifactId>imagej</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.imagej</groupId>
+            <artifactId>imagej-legacy</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/mosaic/BdvTest.java
+++ b/src/main/java/mosaic/BdvTest.java
@@ -41,16 +41,21 @@ public class BdvTest {
         depth = d;
     }
 
-    /**
-     * Creates big data viewer with one big cell containing whole image (good enough for proof of concept)
-     */
-    public void show() {
+    public Img< UnsignedShortType > getImg()
+    {
         final int[] cellDimensions = new int[] { width, heigth, depth};
         final long[] dimensions   = new long[] { width, heigth, depth };
 
         final DiskCachedCellImgOptions options = options().cellDimensions( cellDimensions );
         final CellLoader< UnsignedShortType > loader = new FullImgLoader();
-        final Img< UnsignedShortType > img = new DiskCachedCellImgFactory<>( new UnsignedShortType(), options ).create(dimensions,loader );
+        return new DiskCachedCellImgFactory<>( new UnsignedShortType(), options ).create(dimensions,loader );
+    }
+
+    /**
+     * Creates big data viewer with one big cell containing whole image (good enough for proof of concept)
+     */
+    public void show() {
+        final Img< UnsignedShortType > img = getImg();
 
         BdvStackSource<UnsignedShortType> bdv = BdvFunctions.show( img, "APR TEST" );
 //        bdv.setDisplayRange(0, 7000);

--- a/src/main/java/mosaic/BdvTest.java
+++ b/src/main/java/mosaic/BdvTest.java
@@ -64,8 +64,7 @@ public class BdvTest {
         JavaAPR apr = new JavaAPR();
         
         // ========================   Load APR ===========================
-//        String filename = "/Users/gonciarz/Documents/MOSAIC/work/repo/LibAPR/build/output_apr.h5";
-        String filename = "/Users/gonciarz/Documents/MOSAIC/work/repo/LibAPR-java-wrapper/src/main/resources/sphere_apr.h5";
+        String filename = BdvTest.class.getResource( "/zebra.h5" ).getFile();
         System.out.println("Loading [" + filename + "]");
         //apr.read(url.getPath());
         apr.read(filename);

--- a/src/main/java/mosaic/imagej/AprImg.java
+++ b/src/main/java/mosaic/imagej/AprImg.java
@@ -1,0 +1,44 @@
+package mosaic.imagej;
+
+import mosaic.BdvTest;
+import mosaic.JavaAPR;
+import net.imglib2.img.Img;
+import net.imglib2.img.WrappedImg;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+
+/**
+ * This is intended to be "The data type to represent an APR" in ImageJ.
+ */
+public class AprImg extends ForwardingImg< UnsignedShortType > implements WrappedImg< UnsignedShortType >, AutoCloseable
+{
+	private final Img<  UnsignedShortType > img;
+
+	private final JavaAPR apr;
+
+	private AprImg( Img<  UnsignedShortType > img, JavaAPR apr )
+	{
+		super( img );
+		this.img = img;
+		this.apr = apr;
+	}
+
+	public static AprImg of( JavaAPR apr ) {
+		Img< UnsignedShortType > img = new BdvTest( apr.data(), apr.width(), apr.height(), apr.depth() ).getImg();
+		return new AprImg( img, apr );
+	}
+
+	public Img< UnsignedShortType> getImg() {
+		return img;
+	}
+
+	public JavaAPR getAPR() {
+		return apr;
+	}
+
+	@Override
+	public void close() throws Exception
+	{
+		// TODO: make sure this is called when appropriate
+		apr.close();
+	}
+}

--- a/src/main/java/mosaic/imagej/ForwardingImg.java
+++ b/src/main/java/mosaic/imagej/ForwardingImg.java
@@ -1,0 +1,152 @@
+package mosaic.imagej;
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.Positionable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RealPositionable;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+
+import java.util.Iterator;
+
+/**
+ * Just a wrapper around an {@link Img}.
+ *
+ * It's very useful when you implement something like {@link AprImg}.
+ */
+// TODO: this should be part of imglib2 core
+public class ForwardingImg<T> implements Img<T>
+{
+	private Img< T > img;
+
+	public ForwardingImg( Img< T > img )
+	{
+		this.img = img;
+	}
+
+	@Override public ImgFactory< T > factory()
+	{
+		return img.factory();
+	}
+
+	@Override public Img< T > copy()
+	{
+		return img.copy();
+	}
+
+	@Override public Cursor< T > cursor()
+	{
+		return img.cursor();
+	}
+
+	@Override public Cursor< T > localizingCursor()
+	{
+		return img.localizingCursor();
+	}
+
+	@Override public long size()
+	{
+		return img.size();
+	}
+
+	@Override public T firstElement()
+	{
+		return img.firstElement();
+	}
+
+	@Override public Object iterationOrder()
+	{
+		return img.iterationOrder();
+	}
+
+	@Override public Iterator< T > iterator()
+	{
+		return img.iterator();
+	}
+
+	@Override public long min( int i )
+	{
+		return img.min( i );
+	}
+
+	@Override public void min( long[] longs )
+	{
+		img.min( longs );
+	}
+
+	@Override public void min( Positionable positionable )
+	{
+		img.min( positionable );
+	}
+
+	@Override public long max( int i )
+	{
+		return img.max( i );
+	}
+
+	@Override public void max( long[] longs )
+	{
+		img.max( longs );
+	}
+
+	@Override public void max( Positionable positionable )
+	{
+		img.max( positionable );
+	}
+
+	@Override public void dimensions( long[] longs )
+	{
+		img.dimensions( longs );
+	}
+
+	@Override public long dimension( int i )
+	{
+		return img.dimension( i );
+	}
+
+	@Override public RandomAccess< T > randomAccess()
+	{
+		return img.randomAccess();
+	}
+
+	@Override public RandomAccess< T > randomAccess( Interval interval )
+	{
+		return img.randomAccess( interval );
+	}
+
+	@Override public double realMin( int i )
+	{
+		return img.realMin( i );
+	}
+
+	@Override public void realMin( double[] doubles )
+	{
+		img.realMin( doubles );
+	}
+
+	@Override public void realMin( RealPositionable realPositionable )
+	{
+		img.realMin( realPositionable );
+	}
+
+	@Override public double realMax( int i )
+	{
+		return img.realMax( i );
+	}
+
+	@Override public void realMax( double[] doubles )
+	{
+		img.realMax( doubles );
+	}
+
+	@Override public void realMax( RealPositionable realPositionable )
+	{
+		img.realMax( realPositionable );
+	}
+
+	@Override public int numDimensions()
+	{
+		return img.numDimensions();
+	}
+}

--- a/src/main/java/mosaic/imagej/OpenAprCommand.java
+++ b/src/main/java/mosaic/imagej/OpenAprCommand.java
@@ -11,6 +11,9 @@ import org.scijava.plugin.Plugin;
 
 import java.io.File;
 
+/**
+ * The import APR menu entry.
+ */
 @Plugin( type = Command.class, menuPath = "File > Import > APR..." )
 public class OpenAprCommand implements Command
 {
@@ -18,15 +21,14 @@ public class OpenAprCommand implements Command
 	File file;
 
 	@Parameter(type = ItemIO.OUTPUT)
-	Img<?> output;
+	AprImg output;
 
 	@Override
 	public void run()
 	{
 		JavaAPR apr = new JavaAPR();
 		apr.read( file.getPath() );
-		output = new BdvTest( apr.data(), apr.width(), apr.height(), apr.depth() ).getImg();
-		// TODO apr never gets closed
+		output = AprImg.of(apr);
 	}
 
 	public static void main(String... args)

--- a/src/main/java/mosaic/imagej/OpenAprCommand.java
+++ b/src/main/java/mosaic/imagej/OpenAprCommand.java
@@ -1,0 +1,37 @@
+package mosaic.imagej;
+
+import net.imagej.ImageJ;
+import mosaic.BdvTest;
+import mosaic.JavaAPR;
+import net.imglib2.img.Img;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.io.File;
+
+@Plugin( type = Command.class, menuPath = "File > Import > APR..." )
+public class OpenAprCommand implements Command
+{
+	@Parameter
+	File file;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	Img<?> output;
+
+	@Override
+	public void run()
+	{
+		JavaAPR apr = new JavaAPR();
+		apr.read( file.getPath() );
+		output = new BdvTest( apr.data(), apr.width(), apr.height(), apr.depth() ).getImg();
+		// TODO apr never gets closed
+	}
+
+	public static void main(String... args)
+	{
+		ImageJ imageJ = new ImageJ();
+		imageJ.ui().showUI();
+	}
+}

--- a/src/main/java/mosaic/imagej/ProcessAprExampleCommand.java
+++ b/src/main/java/mosaic/imagej/ProcessAprExampleCommand.java
@@ -1,0 +1,32 @@
+package mosaic.imagej;
+
+import mosaic.JavaAPR;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Example ImageJ plugin that processes an APR.
+ */
+@Plugin( type = Command.class, menuPath = "Process > APR Example" )
+public class ProcessAprExampleCommand implements Command
+{
+
+	@Parameter
+	AprImg input;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	AprImg output;
+
+	@Override public void run()
+	{
+		output = AprImg.of( doSomething( input.getAPR() ) );
+	}
+
+	private JavaAPR doSomething( JavaAPR apr )
+	{
+		// TODO: implement some processing and return the result as JavaAPR
+		return apr;
+	}
+}


### PR DESCRIPTION
A new class AprImg is added, which is a (lazy) imglib2 image, but also has and getAPR method.
ImageJ knows how to work with imglib2 images, and it treats AprImg exactly the same way, which is what we want. AprImg can be input or output parameter to and ImageJ Command. ImageJ will handle it perfectly.

This PR includes and open APR command, and an example process APR command.